### PR TITLE
Make columns optional

### DIFF
--- a/django_custom_indexes/backends/postgresql_psycopg2/schema.py
+++ b/django_custom_indexes/backends/postgresql_psycopg2/schema.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 try:
     # Django >= 1.9
-    from django.db.backends.postgresql.base import *
+    from django.db.backends.postgresql.base import *  # noqa
 
     DEFAULT_BACKEND = 'django.db.backends.postgresql'
 except ImportError:
@@ -20,12 +20,17 @@ class DatabaseSchemaEditor(BASE_MODULE.DatabaseWrapper.SchemaEditorClass):
         CREATE %(unique)s INDEX %(name)s ON %(table)s %(using)s %(columns)s %(where)s
     """
 
-    def add_indexes(self, model, indexes):
+    def _custom_index_name(self, model, field, index):
+        return self.quote_name(self._create_index_name(model, index.get('columns', [field.column]), suffix='_custom'))
+
+    def add_indexes(self, model, field, indexes=None):
+        if indexes is None:
+            indexes = getattr(field, 'custom_indexes', [])
         for index in indexes:
-            columns = ", ".join(index.get('columns', []))
+            columns = ", ".join(index.get('columns', [field.column]))
             name = index.get('name')
             if not name:
-                name = self.quote_name(self._create_index_name(model, index.get('columns'), suffix="_custom"))
+                name = self._custom_index_name(model, field, index)
             self.deferred_sql.append(self.sql_create_custom_index % {
                 "unique": "UNIQUE" if index.get('unique') else "",
                 "name": name,
@@ -38,11 +43,11 @@ class DatabaseSchemaEditor(BASE_MODULE.DatabaseWrapper.SchemaEditorClass):
     def create_model(self, model):
         super(DatabaseSchemaEditor, self).create_model(model)
         for field in model._meta.local_fields:
-            self.add_indexes(model, getattr(field, 'custom_indexes', []))
+            self.add_indexes(model, field)
 
     def add_field(self, model, field):
         super(DatabaseSchemaEditor, self).add_field(model, field)
-        self.add_indexes(model, getattr(field, 'custom_indexes', []))
+        self.add_indexes(model, field)
 
     def _alter_field(self, model, old_field, new_field, old_type, new_type, old_db_params, new_db_params, strict=False):
         super(DatabaseSchemaEditor, self)._alter_field(
@@ -60,10 +65,8 @@ class DatabaseSchemaEditor(BASE_MODULE.DatabaseWrapper.SchemaEditorClass):
             for index in old_indexes:
                 if index not in new_indexes:
                     delete_indexes.append(index)
-        self.add_indexes(model, create_indexes)
+        self.add_indexes(model, new_field, create_indexes)
 
         for index in delete_indexes:
-            name = index.get(
-                'name', self.quote_name(self._create_index_name(model, index['columns'], suffix="_custom"))
-            )
+            name = index.get('name', self._custom_index_name(model, old_field, index))
             self.deferred_sql.append(self.sql_delete_index % {"name": name})


### PR DESCRIPTION
I haven't tested this one for all the cases yet (create model, add field, alter field).

I tested the `WHERE` clause using pytest but had to mock the Django classes quite a bit to be able to run the tests.

To have more automated tests it is probably best to have a django test app set up that can be used to test things. Alternatively, the logic that create the `CREATE INDEX...` statement could be made more independent of Django and then it can be unit tested more.
